### PR TITLE
Handle non-2XX responses

### DIFF
--- a/lib/rack/fluentd_logger.rb
+++ b/lib/rack/fluentd_logger.rb
@@ -60,11 +60,14 @@ module Rack
 
       code, headers, body = response
 
-      if headers['Content-Type'].start_with? 'application/json'
-        body = body.map { |s| self.class.json_parser&.call(s) }
-      else
-        body = body[0..@max_body_non_json]
-      end
+      body = body.body if body.respond_to?(:body)
+      body = [body] if body.is_a? String
+
+      body = if headers['Content-Type'].include? 'json'
+               body.map { |s| self.class.json_parser&.call(s) }
+             else
+               body[0..@max_body_non_json]
+             end
 
       { code: code, body: body, headers: headers }
     end

--- a/lib/rack/fluentd_logger_version.rb
+++ b/lib/rack/fluentd_logger_version.rb
@@ -2,6 +2,6 @@
 
 module Rack
   class FluentdLogger
-    VERSION = '0.1.4'
+    VERSION = '0.1.5'
   end
 end


### PR DESCRIPTION
When the response is with error (404, 500 etc) `body` is an instance of `ActionDispatch::Response::RackBody` so we should call `body.body` to get the actual response `body`.